### PR TITLE
Fix bulkhead configuration property key.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,13 +73,13 @@ resilience4j.retry:
 resilience4j.bulkhead:
     configs:
         default:
-            maxConcurrentCall: 100
+            maxConcurrentCalls: 100
     instances:
         backendA:
-            maxConcurrentCall: 10
+            maxConcurrentCalls: 10
         backendB:
-            maxWaitTimeDuration: 10ms
-            maxConcurrentCall: 20
+            maxWaitDuration: 10ms
+            maxConcurrentCalls: 20
 
 resilience4j.thread-pool-bulkhead:
     configs:


### PR DESCRIPTION
Fix bulkhead configuration property key.

- maxConcurrentCall not exists
changed to maxConcurrentCalls.

- maxWaitTimeDuration not exists
changed to maxWaitDuration.

This solves the issues #11 and #12.