### PR TITLE
Added configuration for local Docker desktop environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM gradle:5.4.0-jdk8-alpine
-ADD . /code
+ADD --chown=gradle . /code
 WORKDIR /code
-RUN gradle clean package -DskipTests=true
-CMD gradle spring-boot:run
+RUN gradle clean build -x test
+CMD gradle bootRun

--- a/docker-compose-desktop.yml
+++ b/docker-compose-desktop.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./docker/prometheus-desktop.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - net
+    depends_on:
+      - app
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    env_file:
+      - ./docker/grafana.env
+    ports:
+      - "3000:3000"
+    networks:
+      - net
+  app:
+  # build and start spring application inside a separate container using the same network as prometheus
+    build: .
+    ports:
+      - "9080:9080"
+    networks:
+      - net
+networks:
+  net:

--- a/docker/prometheus-desktop.yml
+++ b/docker/prometheus-desktop.yml
@@ -1,0 +1,31 @@
+
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'resilience4j-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name:       'resilience4j-spring-boot2-demo'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    metrics_path: /actuator/prometheus
+
+    static_configs:
+      # Use the service name (see docker-compose-desktop.yml) instead of localhost
+      - targets: ['app:9080']


### PR DESCRIPTION
Hi,
we tried out the example locally, but ran into some problems which we wanted to contribute.
The problem we had came from the "network_mode" setting ("host") in the docker-compose file, which did not work for our Docker Desktop setup. Instead we used the bridging mechansim with shared network. Furthermore we needed to fix the Dockerfile to start the spring app inside the docker-compose file.