### PR TITLE
Timelimiter property not getting injected because of key mismatch

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,7 +117,8 @@ resilience4j.ratelimiter:
             limitForPeriod: 6
             limitRefreshPeriod: 500ms
             timeoutDuration: 3s
-resilience4j:
+            
+resilience4j.timelimiter:
     configs:
         default:
             cancelRunningFuture: false


### PR DESCRIPTION
Timelimiter property not getting injected because of key mismatch