### PR TITLE
Fix issue failure rate doesn't become updated in Grafana

### DIFF
--- a/docker/dashboard.json
+++ b/docker/dashboard.json
@@ -478,7 +478,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "resilience4j_circuitbreaker_failure_rate{instance=\"$instance\",name=\"$circuitbreaker_name\"}",
+          "expr": "resilience4j_circuitbreaker_failure_rate{application=\"$application\",name=\"$circuitbreaker_name\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
When I tested monitoring of resilience4j-spring-boot2-demo, I found the issue that Failure rate doesn't become updated in Grafana.

As you can see information about failure rate in Prometheus, I changed the keys.

```bash
# HELP resilience4j_circuitbreaker_failure_rate The failure rate of the circuit breaker
# TYPE resilience4j_circuitbreaker_failure_rate gauge
resilience4j_circuitbreaker_failure_rate{application="resilience4j-demo",name="backendA",} 0.0
resilience4j_circuitbreaker_failure_rate{application="resilience4j-demo",name="backendB",} 100.0
# HELP system_cpu_usage The "recent cpu usage" for the whole system
...
```