### PR TITLE
[updates] Upgrade tests to use JUnit 5 and Gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:5.4.0-jdk8-alpine
+FROM gradle:6.9.0-jdk8-alpine
 ADD --chown=gradle . /code
 WORKDIR /code
 RUN gradle clean build -x test

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ ext{
 	resilience4jVersion = '1.7.1'
 }
 
+test {
+	useJUnitPlatform()
+}
+
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-webflux')
 	compile('org.springframework.boot:spring-boot-starter-actuator')

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     jackson.serialization.indent_output: true
 
 server:
-    port: 9081
+    port: 9080
 
 management.endpoints.web.exposure.include: '*'
 management.endpoint.health.show-details: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,7 +117,7 @@ resilience4j.ratelimiter:
             limitForPeriod: 6
             limitRefreshPeriod: 500ms
             timeoutDuration: 3s
-            
+
 resilience4j.timelimiter:
     configs:
         default:

--- a/src/test/java/io/github/robwin/AbstractIntegrationTest.java
+++ b/src/test/java/io/github/robwin/AbstractIntegrationTest.java
@@ -1,18 +1,18 @@
 package io.github.robwin;
 
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @AutoConfigureWebTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = Application.class)
@@ -30,7 +30,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired
     protected WebTestClient webClient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         transitionToClosedState(BACKEND_A);
         transitionToClosedState(BACKEND_B);

--- a/src/test/java/io/github/robwin/AbstractIntegrationTest.java
+++ b/src/test/java/io/github/robwin/AbstractIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.robwin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.metrics.AutoConfigureMetrics;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -14,6 +15,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
 @ExtendWith(SpringExtension.class)
 @AutoConfigureWebTestClient
+@AutoConfigureMetrics
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = Application.class)
 public abstract class AbstractIntegrationTest {

--- a/src/test/java/io/github/robwin/CircuitBreakerTest.java
+++ b/src/test/java/io/github/robwin/CircuitBreakerTest.java
@@ -3,7 +3,7 @@ package io.github.robwin;
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/io/github/robwin/FutureCircuitBreakerTest.java
+++ b/src/test/java/io/github/robwin/FutureCircuitBreakerTest.java
@@ -3,7 +3,7 @@ package io.github.robwin;
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/io/github/robwin/FutureRetryTest.java
+++ b/src/test/java/io/github/robwin/FutureRetryTest.java
@@ -2,9 +2,7 @@ package io.github.robwin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -53,6 +51,5 @@ public class FutureRetryTest extends AbstractRetryTest {
 		ResponseEntity<String> response = restTemplate.getForEntity("/" + backend + "/futureSuccess", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
-
 
 }

--- a/src/test/java/io/github/robwin/ReactiveCircuitBreakerTest.java
+++ b/src/test/java/io/github/robwin/ReactiveCircuitBreakerTest.java
@@ -2,9 +2,8 @@ package io.github.robwin;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
 
-import org.junit.Test;
-
 import io.vavr.collection.Stream;
+import org.junit.jupiter.api.Test;
 
 public class ReactiveCircuitBreakerTest extends AbstractCircuitBreakerTest {
 
@@ -59,4 +58,5 @@ public class ReactiveCircuitBreakerTest extends AbstractCircuitBreakerTest {
 		webClient.get().uri("/" + backend + "/monoSuccess").exchange().expectStatus()
 				.isOk();
 	}
+
 }

--- a/src/test/java/io/github/robwin/ReactiveRetryTest.java
+++ b/src/test/java/io/github/robwin/ReactiveRetryTest.java
@@ -1,14 +1,8 @@
 package io.github.robwin;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +51,5 @@ public class ReactiveRetryTest extends AbstractRetryTest {
 		ResponseEntity<String> response = restTemplate.getForEntity("/" + backend + "/monoSuccess", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
-
 
 }

--- a/src/test/java/io/github/robwin/RetryTest.java
+++ b/src/test/java/io/github/robwin/RetryTest.java
@@ -1,14 +1,8 @@
 package io.github.robwin;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
* Added JUnit 5 platform and cleaned-up the tests accordingly.
* Upgraded Gradle version (6.9.0)
* Changed application port to 9080 (it is the one documented)